### PR TITLE
test(config): set phpstan level and paths directly in the config

### DIFF
--- a/quality-analysis/phpstan/phpstan.neon
+++ b/quality-analysis/phpstan/phpstan.neon
@@ -1,2 +1,5 @@
 parameters:
+    level: 7
+    paths:
+        - src
     bootstrap: quality-analysis/phpstan/bootstrap.php


### PR DESCRIPTION
We'll be able to use:

```
./vendor/bin/phpstan analyse -c quality-analysis/phpstan/phpstan.neon
```

instead of

```
./vendor/bin/phpstan analyse src --level=7 -c quality-analysis/phpstan/phpstan.neon
```