### PR TITLE
fix(action): temporarily disable twig strict variable action

### DIFF
--- a/src/Action/ActionManager.php
+++ b/src/Action/ActionManager.php
@@ -96,7 +96,9 @@ class ActionManager
             DisplayPrettyExceptionsASAPAction::class,
             EnableDebugClassLoaderAction::class,
             EnableTwigDebugAction::class,
-            EnableTwigStrictVariablesAction::class,
+            // Drupal Core does not handle strict variables. temporarily
+            // @see https://www.drupal.org/project/drupal/issues/2445705
+            //EnableTwigStrictVariablesAction::class,
             ThrowErrorsAsExceptionsAction::class,
             WatchContainerDefinitionsAction::class,
             WatchHooksImplementationsAction::class,


### PR DESCRIPTION
Drupal Core does not handle and support the Twig strict variable. See https://www.drupal.org/project/drupal/issues/2445705.
For the moment we could comment it and discuss this later.

