### PR TITLE
feat(throw-errors-as-exceptions): don't throw on warnings by default

### DIFF
--- a/src/Action/ThrowErrorsAsExceptions/ThrowErrorsAsExceptionsOptions.php
+++ b/src/Action/ThrowErrorsAsExceptions/ThrowErrorsAsExceptionsOptions.php
@@ -63,6 +63,6 @@ class ThrowErrorsAsExceptionsOptions implements OptionsInterface
      */
     public static function getDefault(string $appRoot, DefaultsConfiguration $defaultsConfiguration): OptionsInterface
     {
-        return new self(E_ALL, $defaultsConfiguration->getLogger());
+        return new self(E_ALL & ~E_WARNING & ~E_USER_WARNING, $defaultsConfiguration->getLogger());
     }
 }

--- a/tests/Unit/src/Action/ThrowErrorsAsExceptions/ThrowErrorsAsExceptionsOptionsTest.php
+++ b/tests/Unit/src/Action/ThrowErrorsAsExceptions/ThrowErrorsAsExceptionsOptionsTest.php
@@ -53,6 +53,6 @@ class ThrowErrorsAsExceptionsOptionsTest extends TestCase
             ->method('getLogger')
             ->willReturn(null);
 
-        $this->assertEquals(new ThrowErrorsAsExceptionsOptions(E_ALL, null), ThrowErrorsAsExceptionsOptions::getDefault('/foo', $defaultsConfiguration));
+        $this->assertEquals(new ThrowErrorsAsExceptionsOptions(E_ALL & ~E_WARNING & ~E_USER_WARNING, null), ThrowErrorsAsExceptionsOptions::getDefault('/foo', $defaultsConfiguration));
     }
 }


### PR DESCRIPTION
This is the only non easily configurable option at the moment and since Drupal is currently silencing those kind of errors, I don't think existing projects are ready for this by default ^^