### PR TITLE
feat(commands-kernel-substitution): add aliases to enable/disable kernel substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ Here is the list of all the actions that have options :
 
 Here is the list of the provided Composer commands that help you manage the configuration file:
 
-| Command                                                           | Description                                                                     |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| composer drupal-debug:dump-reference-configuration-file           | Dump the reference configuration file                                           |
-| composer drupal-debug:disable-original-drupal-kernel-substitution | Alter the configuration file to disable the original Drupal Kernel substitution |
-| composer drupal-debug:enable-original-drupal-kernel-substitution  | Alter the configuration file to enable the original Drupal Kernel substitution  |
+| Command                                                           | Alias                         | Description                                                                     |
+| ----------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------- |
+| composer drupal-debug:dump-reference-configuration-file           | None                          | Dump the reference configuration file                                           |
+| composer drupal-debug:disable-original-drupal-kernel-substitution | composer drupal-debug:disable | Alter the configuration file to disable the original Drupal Kernel substitution |
+| composer drupal-debug:enable-original-drupal-kernel-substitution  | composer drupal-debug:enable  | Alter the configuration file to enable the original Drupal Kernel substitution  |
 
 # Original Drupal Kernel substitution
 

--- a/src/Composer/Command/DisableOriginalDrupalKernelSubstitutionCommand.php
+++ b/src/Composer/Command/DisableOriginalDrupalKernelSubstitutionCommand.php
@@ -26,11 +26,18 @@ class DisableOriginalDrupalKernelSubstitutionCommand extends BaseCommand
     const NAME = 'drupal-debug:disable-original-drupal-kernel-substitution';
 
     /**
+     * @var string
+     */
+    const ALIASES = array('drupal-debug:disable');
+
+    /**
      * {@inheritdoc}
      */
     protected function configure(): void
     {
-        $this->setName(self::NAME);
+        $this
+            ->setName(self::NAME)
+            ->setAliases(self::ALIASES);
     }
 
     /**

--- a/src/Composer/Command/EnableOriginalDrupalKernelSubstitutionCommand.php
+++ b/src/Composer/Command/EnableOriginalDrupalKernelSubstitutionCommand.php
@@ -26,11 +26,18 @@ class EnableOriginalDrupalKernelSubstitutionCommand extends BaseCommand
     const NAME = 'drupal-debug:enable-original-drupal-kernel-substitution';
 
     /**
+     * @var string
+     */
+    const ALIASES = array('drupal-debug:enable');
+
+    /**
      * {@inheritdoc}
      */
     protected function configure(): void
     {
-        $this->setName(self::NAME);
+        $this
+            ->setName(self::NAME)
+            ->setAliases(self::ALIASES);
     }
 
     /**


### PR DESCRIPTION
Commands `composer drupal-debug:disable-original-drupal-kernel-substitution` and 
`composer drupal-debug:enable-original-drupal-kernel-substitution` are too long to write.

This add the following aliases:

| Command                                                           | Alias                         |
| ----------------------------------------------------------------- | ----------------------------- |
| `composer drupal-debug:disable-original-drupal-kernel-substitution` | `composer drupal-debug:disable` |
| `composer drupal-debug:enable-original-drupal-kernel-substitution`  | `composer drupal-debug:enable`  |
